### PR TITLE
decorator==4.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ scenedetect
 moviepy==1.0.3
 huggingface_hub==0.26.2
 mediapipe
+decorator==4.4.2


### PR DESCRIPTION
In `convert_fps` trigger error 
```
TypeError: must be real number, not NoneType
```

decorator==4.4.2 can fix it